### PR TITLE
#25: handling permanent, document-scoped slugs in subdocument array.

### DIFF
--- a/lib/slug-generator.js
+++ b/lib/slug-generator.js
@@ -334,6 +334,7 @@ async function findSame(
   isCounter,
   options,
   findOne,
+  permanent
   // slugsMdfPaths
 ) {
   // console.log(`findSame#${doc.n} ${path}: ${slug}`);
@@ -380,7 +381,7 @@ async function findSame(
         query._id = {
           $ne: doc._id,
         };
-      } else {
+      } else if (!permanent) {
         query = false;
       }
     }
@@ -572,6 +573,7 @@ async function setSlugs(doc, slugs, options, findOne, cache) {
                 query,
                 findOne,
                 cache,
+                slug.permanent
                 // slugsMdfPaths
               ),
             );
@@ -609,6 +611,7 @@ async function makeUniqueCounterSlug(
   groups,
   findOne,
   cache,
+  permanent,
   // slugsMdfPaths
 ) {
   let slug = makeSlug(values, options);
@@ -624,6 +627,7 @@ async function makeUniqueCounterSlug(
     true,
     options,
     findOne,
+    permanent
     // slugsMdfPaths
   );
   if (result) {

--- a/test/uniqueNestedGroup.js
+++ b/test/uniqueNestedGroup.js
@@ -21,6 +21,22 @@ const childSchema = mongoose.Schema({
   },
 });
 
+const childPermenantSchema = mongoose.Schema({
+  title: {
+    type: String,
+    required: true,
+    maxlength: 100,
+  },
+  slug: {
+    type: String,
+    slug: 'title',
+    index: true,
+    permanent: true,
+    slugPaddingSize: 4,
+    uniqueGroupSlug: '/_id',
+  },
+});
+
 const scratchSchema = mongoose.Schema({
   title: {
     type: String,
@@ -52,7 +68,17 @@ const scratchSchema = mongoose.Schema({
   // ],
 });
 
+const scratchPermanentSchema = mongoose.Schema({
+  title: {
+    type: String,
+    required: true,
+    maxlength: 100,
+  },
+  children: [childPermenantSchema],
+});
+
 const Scratch = mongoose.model('scratchSchema', scratchSchema);
+const ScratchPermanent = mongoose.model('scratchPermenantSchema', scratchPermanentSchema);
 
 describe('Grouped Nested Resources (Counter)', function () {
   before(async () => {
@@ -105,5 +131,35 @@ describe('Grouped Nested Resources (Counter)', function () {
 
     doc.should.have.nested.property('children[1].title').and.equal('This is subtitle');
     doc.should.have.nested.property('children[1].slug').and.equal('this-is-subtitle-0001');
+  });
+
+  it('Update existing resource with additional child and check children are unique locally', async () => {
+    const doc = await ScratchPermanent.create({
+      title: 'This is a long title',
+      children: [
+        {
+          title: 'This is nested subtitle',
+        },
+        {
+          title: 'This is nested subtitle',
+        },
+      ],
+    });
+
+    doc.children.push(
+    {
+      title: 'This is nested subtitle',
+    });
+    await doc.save();
+
+
+    doc.should.have.nested.property('children[0].title').and.equal('This is nested subtitle');
+    doc.should.have.nested.property('children[0].slug').and.equal('this-is-nested-subtitle');
+
+    doc.should.have.nested.property('children[1].title').and.equal('This is nested subtitle');
+    doc.should.have.nested.property('children[1].slug').and.equal('this-is-nested-subtitle-0001');
+
+    doc.should.have.nested.property('children[2].title').and.equal('This is nested subtitle');
+    doc.should.have.nested.property('children[2].slug').and.equal('this-is-nested-subtitle-0002');
   });
 });


### PR DESCRIPTION
If a subdocument array has a slug which is (1) permanent, and (2) scoped to the parent document (via the '/_id' `uniqueGroupSlug), then subdocuments that are added to the array will not receive unique slugs. 

I'm not sure that this fix behaves ideally in every situation, but it does fix the immediate issue, and allows existing test cases to run without error.